### PR TITLE
Add Rudamentary Layer-Writing Capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ install:
 	python3 setup.py install --user
 
 backend-assembly:
-	cd geopyspark-backend && sbt "project geotrellis-backend" assembly
+	(cd geopyspark-backend ; ./sbt "project geotrellis-backend" assembly)
 
 run-pyspark:
+	PYSPARK_PYTHON=python3 PYSPARK_DRIVER_PYTHON=python3 \
 	spark-submit \
 		--master "local[*]" \
 		--jars geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar \

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -25,6 +25,7 @@ class HadoopLayerReaderWrapper(uri: String, sc: SparkContext)
 
   def query(name: String, zoom: Int): (JavaRDD[Array[Byte]], String) = {
     val id = LayerId(name, zoom)
+    // val results = layerReader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id)
     val subset = Extent(-87.1875, 34.43409789359469, -78.15673828125, 39.87601941962116)
     val results = layerReader
       .query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
@@ -1,0 +1,55 @@
+package geopyspark.geotrellis.io
+
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.io.index.ZCurveKeyIndexMethod
+import geotrellis.vector._
+
+import org.apache.spark._
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.rdd.RDD
+
+import geopyspark.geotrellis.PythonTranslator
+
+
+abstract class LayerWriterWrapper {
+  def write(
+    name: String, zoom: Int,
+    jrdd: JavaRDD[Array[Byte]], schema: String,
+    metaname: String, metazoom: Int
+  ): Unit
+}
+
+class HadoopLayerWriterWrapper(uri: String, sc: SparkContext)
+    extends LayerWriterWrapper {
+
+  val attributeStore = HadoopAttributeStore(uri)(sc)
+  val layerWriter = HadoopLayerWriter(uri)(sc)
+
+  def write(
+    name: String, zoom: Int,
+    jrdd: JavaRDD[Array[Byte]], schema: String,
+    metaName: String, metaZoom: Int
+  ): Unit = {
+    val id = LayerId(name, zoom)
+    val metaId = LayerId(metaName, metaZoom)
+    // val metadata = attributeStore.readMetadata[SpatialKey](metaName, metaZoom)
+    val layerReader = HadoopLayerReader(uri)(sc)
+    val metadata: TileLayerMetadata[SpatialKey] = layerReader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](metaId).metadata
+    val rawRdd = PythonTranslator.fromPython[(SpatialKey, Tile)](jrdd, Some(schema))
+    val rdd = ContextRDD(rawRdd, metadata)
+
+    layerWriter.write(id, rdd, ZCurveKeyIndexMethod)
+  }
+}
+
+object LayerWriterFactory {
+  def build(backend: String, uri: String, sc: SparkContext): LayerWriterWrapper = {
+    backend match {
+      case "hdfs" => new HadoopLayerWriterWrapper(uri, sc)
+      case _ => throw new Exception
+    }
+  }
+}

--- a/geopyspark/tests/layer_test.py
+++ b/geopyspark/tests/layer_test.py
@@ -6,6 +6,9 @@ from pyspark import SparkConf, SparkContext, RDD
 from pyspark.serializers import AutoBatchedSerializer
 from geopyspark.avroserializer import AvroSerializer
 
+import time
+import calendar
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 3:
@@ -29,3 +32,7 @@ if __name__ == "__main__":
     serializer = AvroSerializer(schema)
     rdd = RDD(jrdd, sc, AutoBatchedSerializer(serializer))
     print(rdd.take(1))
+
+    writer_factory = sc._gateway.jvm.geopyspark.geotrellis.io.LayerWriterFactory
+    writer = writer_factory.build("hdfs", uri, sc._jsc.sc())
+    writer.write(layer_name + "-" + str(calendar.timegm(time.gmtime())), 0, rdd._jrdd, schema, layer_name, layer_zoom)


### PR DESCRIPTION
Layer-writing capability has been added to the Scala code and the capability is exercised in the `layer_test.py` file.

I was able to read a layer from HDFS into PySpark, write the layer back out to HDFS using PySpark, then ingest the PySpark-written layer into GeoWave and view it in GeoServer, so (at least in this instance) the capability seems to be working.

![screenshot from 2017-01-09 13 06 39](https://cloud.githubusercontent.com/assets/11281373/21777974/6138b082-d66f-11e6-9f75-5abf09e11885.png)